### PR TITLE
Fit errcheck presubmit errors.

### DIFF
--- a/editor/editor_test.go
+++ b/editor/editor_test.go
@@ -52,10 +52,9 @@ func TestMainImmediateQuit(t *testing.T) {
 	terminal := NewTerminalFake(80, 25, []TerminalEvent{})
 	editor, err := MakeEditor(terminal, true)
 	ut.AssertEqual(t, nil, err)
-	closeEditor := func() {
+	defer func() {
 		_ = editor.Close()
-	}
-	defer closeEditor()
+	}()
 
 	wicore.PostCommand(editor, nil, "editor_bootstrap_ui")
 	wicore.PostCommand(editor, nil, "new")
@@ -80,10 +79,9 @@ func TestMainInvalidThenQuit(t *testing.T) {
 	terminal := NewTerminalFake(80, 25, []TerminalEvent{})
 	editor, err := MakeEditor(terminal, true)
 	ut.AssertEqual(t, nil, err)
-	closeEditor := func() {
+	defer func() {
 		_ = editor.Close()
-	}
-	defer closeEditor()
+	}()
 
 	wicore.PostCommand(editor, nil, "editor_bootstrap_ui")
 	wicore.PostCommand(editor, nil, "invalid")

--- a/editor/editor_test.go
+++ b/editor/editor_test.go
@@ -30,7 +30,7 @@ func keepLog(t *testing.T) func() {
 	log.SetOutput(out)
 	return func() {
 		log.SetOutput(ioutil.Discard)
-		out.Close()
+		_ = out.Close()
 	}
 }
 
@@ -52,7 +52,10 @@ func TestMainImmediateQuit(t *testing.T) {
 	terminal := NewTerminalFake(80, 25, []TerminalEvent{})
 	editor, err := MakeEditor(terminal, true)
 	ut.AssertEqual(t, nil, err)
-	defer editor.Close()
+	closeEditor := func() {
+		_ = editor.Close()
+	}
+	defer closeEditor()
 
 	wicore.PostCommand(editor, nil, "editor_bootstrap_ui")
 	wicore.PostCommand(editor, nil, "new")
@@ -77,7 +80,10 @@ func TestMainInvalidThenQuit(t *testing.T) {
 	terminal := NewTerminalFake(80, 25, []TerminalEvent{})
 	editor, err := MakeEditor(terminal, true)
 	ut.AssertEqual(t, nil, err)
-	defer editor.Close()
+	closeEditor := func() {
+		_ = editor.Close()
+	}
+	defer closeEditor()
 
 	wicore.PostCommand(editor, nil, "editor_bootstrap_ui")
 	wicore.PostCommand(editor, nil, "invalid")


### PR DESCRIPTION
Without this patch, presubmit fails when running errcheck.